### PR TITLE
Subtitles Toggle & Overlay Message

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ loom_version=1.15-SNAPSHOT
 java_version=25
 
 # Mod Properties
-mod_version=2.2+26.1
+mod_version=2.3+26.1
 maven_group=net.naw
 archives_base_name=subtitlesplus
 

--- a/src/main/java/net/naw/subtitles/client/SubtitleConfig.java
+++ b/src/main/java/net/naw/subtitles/client/SubtitleConfig.java
@@ -55,7 +55,6 @@ public class SubtitleConfig {
     // --- FEATURE TOGGLES ---
     // Controls which features are active: colors, icons, preview, guides, alignment, etc.
     public boolean useCategoryColors = true;
-    public boolean renderSubtitles = true;
     public boolean showGuides = true;
     public boolean showIcons = true;
     public int previewMode = 2; // 0: OFF, 1: Outline+Labels only, 2: Full preview

--- a/src/main/java/net/naw/subtitles/client/SubtitlesClient.java
+++ b/src/main/java/net/naw/subtitles/client/SubtitlesClient.java
@@ -42,20 +42,16 @@ public class SubtitlesClient implements ClientModInitializer {
 
             // Toggle subtitle visibility
             while (toggleKey.consumeClick()) {
-                if (!(Boolean)client.options.showSubtitles().get()) {
-                    if (client.player != null)
-                        client.player.sendSystemMessage(Component.literal("§eEnable Closed Captions in Music & Sounds first!"));
-                    continue;
-                }
-                SubtitleConfig.INSTANCE.renderSubtitles = !SubtitleConfig.INSTANCE.renderSubtitles;
-                SubtitleConfig.INSTANCE.save();
+                boolean active = !client.options.showSubtitles().get();
+                client.options.showSubtitles().set(active);
+                client.options.save();
 
-                // Feedback message for the player
-                if (client.player != null) {
-                    Component status = SubtitleConfig.INSTANCE.renderSubtitles ?
-                            Component.literal("§aSubtitles Shown") : Component.literal("§cSubtitles Hidden");
-                    client.player.sendSystemMessage(status);
-                }
+				// Feedback message for the player
+                Component status = active
+                        ? Component.literal("Subtitles: §aON")
+                        : Component.literal("Subtitles: §cOFF");
+
+                client.gui.setOverlayMessage(status, false);
             }
         });
     }

--- a/src/main/java/net/naw/subtitles/client/mixin/SubtitlesMixin.java
+++ b/src/main/java/net/naw/subtitles/client/mixin/SubtitlesMixin.java
@@ -63,7 +63,6 @@ public abstract class SubtitlesMixin {
         ci.cancel();
         SubtitleConfig config = SubtitleConfig.INSTANCE;
 
-        if (!config.renderSubtitles) return;
         if (!(Boolean)this.minecraft.options.showSubtitles().get()) return;
 
         // Transform handles where the player is looking (important for the arrows!)


### PR DESCRIPTION
currently you have to enable the "Closed Captions" setting in the Minecraft options, in order for the "Subtitles+ Show/Hide Toggle" (default: H) to work. if the "Closed Captions" setting is disabled, then pressing H wont do anything. i simplified the logic by removing the two-flag dependency and accessing the "Closed Captions" setting directly. pressing H will now correctly toggle the subtitles on/off.

i also changed the notification from a chat message to an overlay message, to avoid cluttering the chat window with unnecessary system messages.